### PR TITLE
squash equal transitive edges

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -157,7 +157,7 @@ NumericLiterals:
 OneLineConditional:
   Enabled: false
 
-OpMethod:
+BinaryOperatorParameterName:
   Enabled: false
 
 ParameterLists:
@@ -236,9 +236,6 @@ ElseLayout:
   Enabled: false
 
 HandleExceptions:
-  Enabled: false
-
-InvalidCharacterLiteral:
   Enabled: false
 
 LiteralInCondition:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.4.1
+  - 2.4.2
 
 sudo: false
 
@@ -20,6 +20,9 @@ env:
   matrix:
     - "DB=postgresql"
     - "DB=mysql"
+
+addons:
+  postgresql: "9.5"
 
 before_script:
   - 'if [ $DB = "mysql" ]; then

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    typed_dag (1.0.0)
+    typed_dag (1.0.1)
       rails (>= 5.0.4)
 
 GEM
@@ -50,18 +50,16 @@ GEM
     crass (1.0.2)
     diff-lcs (1.3)
     erubi (1.7.0)
-    globalid (0.4.0)
+    globalid (0.4.1)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.6.6)
-      mime-types (>= 1.16, < 4)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
     method_source (0.9.0)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mini_mime (0.1.4)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     mysql2 (0.4.9)
@@ -138,4 +136,4 @@ DEPENDENCIES
   typed_dag!
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/lib/typed_dag/configuration.rb
+++ b/lib/typed_dag/configuration.rb
@@ -56,6 +56,10 @@ class TypedDag::Configuration
     config[:to_column] || 'to_id'
   end
 
+  def count_column
+    config[:count_column] || 'count'
+  end
+
   def types
     config[:types] || default_types
   end

--- a/lib/typed_dag/sql.rb
+++ b/lib/typed_dag/sql.rb
@@ -6,5 +6,6 @@ module TypedDag
     require 'typed_dag/sql/get_circular'
     require 'typed_dag/sql/remove_invalid_relation'
     require 'typed_dag/sql/insert_reflexive'
+    require 'typed_dag/sql/delete_zero_count'
   end
 end

--- a/lib/typed_dag/sql/add_closure.rb
+++ b/lib/typed_dag/sql/add_closure.rb
@@ -15,18 +15,49 @@ module TypedDag::Sql::AddClosure
 
     def sql
       <<-SQL
-        INSERT INTO #{table_name}
-          (#{from_column},
-          #{to_column},
-          #{type_select_list})
-        #{closure_select}
+        #{insert_sql}
+        #{on_duplicate}
       SQL
     end
 
     private
 
+    def on_duplicate
+      if helper.mysql_db?
+        on_duplicate_mysql
+      else
+        on_duplicate_postgresql
+      end
+    end
+
+    def on_duplicate_mysql
+      <<-SQL
+        ON DUPLICATE KEY
+        UPDATE #{count_column} = #{table_name}.#{count_column} + VALUES(#{count_column})
+      SQL
+    end
+
+    def on_duplicate_postgresql
+      <<-SQL
+        ON CONFLICT (#{column_list})
+        DO UPDATE SET #{count_column} = #{table_name}.#{count_column} + EXCLUDED.#{count_column}
+      SQL
+    end
+
+    def insert_sql
+      <<-SQL
+        INSERT INTO #{table_name}
+          (#{column_list}, #{count_column})
+        #{closure_select}
+      SQL
+    end
+
     def closure_select
       TypedDag::Sql::SelectClosure.sql(relation)
+    end
+
+    def column_list
+      "#{from_column}, #{to_column}, #{type_select_list}"
     end
   end
 end

--- a/lib/typed_dag/sql/delete_zero_count.rb
+++ b/lib/typed_dag/sql/delete_zero_count.rb
@@ -1,0 +1,22 @@
+require 'typed_dag/sql/helper'
+
+module TypedDag::Sql::DeleteZeroCount
+  def self.sql(relation)
+    Sql.new(relation).sql
+  end
+
+  class Sql
+    include TypedDag::Sql::RelationAccess
+
+    def initialize(relation)
+      self.relation = relation
+    end
+
+    def sql
+      <<-SQL
+        DELETE FROM #{table_name}
+        WHERE #{count_column} = 0
+      SQL
+    end
+  end
+end

--- a/lib/typed_dag/sql/get_circular.rb
+++ b/lib/typed_dag/sql/get_circular.rb
@@ -13,8 +13,10 @@ module TypedDag::Sql::GetCircular
     def sql(depth)
       <<-SQL
         SELECT
-          r1.#{helper.from_column},
-          r1.#{helper.to_column}
+          r1.#{helper.from_column} AS r1_from_column,
+          r1.#{helper.to_column} AS r1_to_column,
+          r2.#{helper.from_column} AS r2_from_column,
+          r2.#{helper.to_column} AS r2_to_column
         FROM #{helper.table_name} r1
         JOIN #{helper.table_name} r2
         ON #{join_condition(depth)}

--- a/lib/typed_dag/sql/helper.rb
+++ b/lib/typed_dag/sql/helper.rb
@@ -23,13 +23,23 @@ class TypedDag::Sql::Helper
     configuration.type_columns
   end
 
+  def count_column
+    configuration.count_column
+  end
+
   def type_select_list
     type_columns.join(', ')
   end
 
   def type_select_summed_columns(prefix1, prefix2)
     type_columns
-      .map { |column| "#{prefix1}.#{column} + #{prefix2}.#{column}" }
+      .map { |column| "#{prefix1}.#{column} + #{prefix2}.#{column} " }
+      .join(', ')
+  end
+
+  def type_select_summed_columns_aliased(prefix1, prefix2)
+    type_columns
+      .map { |column| "(#{prefix1}.#{column} + #{prefix2}.#{column}) #{column}" }
       .join(', ')
   end
 
@@ -43,6 +53,10 @@ class TypedDag::Sql::Helper
 
   def exactly_one_type_column_eql_1(prefix = '')
     type_columns.map { |column| "#{prefix}#{column} = 1" }.join(' XOR ')
+  end
+
+  def mysql_db?
+    ActiveRecord::Base.connection.adapter_name == 'Mysql2'
   end
 
   private

--- a/lib/typed_dag/sql/insert_reflexive.rb
+++ b/lib/typed_dag/sql/insert_reflexive.rb
@@ -14,8 +14,9 @@ module TypedDag::Sql::InsertReflexive
       <<-SQL
         INSERT INTO #{helper.table_name}
           (#{helper.from_column},
-           #{helper.to_column})
-        SELECT id, id
+           #{helper.to_column},
+           #{helper.count_column})
+        SELECT id, id, 1
         FROM #{helper.node_table_name}
       SQL
     end

--- a/lib/typed_dag/sql/relation_access.rb
+++ b/lib/typed_dag/sql/relation_access.rb
@@ -11,6 +11,7 @@ module TypedDag::Sql::RelationAccess
     delegate :table_name,
              :from_column,
              :to_column,
+             :count_column,
              :type_columns,
              :type_select_list,
              to: :helper

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -30,8 +30,17 @@ module TypedDag
           [r.from.text,
            r.to.text,
            r.hierarchy,
-           r.invalidate]
+           r.invalidate,
+           r.count]
         end
+      end
+
+      def mysql_db?
+        ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      end
+
+      def harmonize_string(string)
+        string.squish.gsub('( ', '(').gsub(' )', ')')
       end
     end
   end

--- a/spec/test_app/db/migrate/20170831093433_create_nodes_and_endges.rb
+++ b/spec/test_app/db/migrate/20170831093433_create_nodes_and_endges.rb
@@ -10,11 +10,10 @@ class CreateNodesAndEndges < ActiveRecord::Migration[5.1]
 
       t.column :hierarchy, :integer, null: false, default: 0
       t.column :invalidate, :integer, null: false, default: 0
-      t.column :mention, :integer, null: false, default: 0
 
-      t.index :hierarchy
-      t.index :invalidate
-      t.index :mention
+      t.column :count, :integer, null: false, default: 1
+
+      t.index %i(ancestor_id descendant_id hierarchy invalidate), unique: true, name: 'unique_constraint'
     end
 
     add_foreign_key :relations, :messages, column: :ancestor_id

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -24,12 +24,10 @@ ActiveRecord::Schema.define(version: 20170831093433) do
     t.bigint "descendant_id", null: false
     t.integer "hierarchy", default: 0, null: false
     t.integer "invalidate", default: 0, null: false
-    t.integer "mention", default: 0, null: false
+    t.integer "count", default: 0, null: false
+    t.index ["ancestor_id", "descendant_id", "hierarchy", "invalidate"], name: "unique_constraint", unique: true
     t.index ["ancestor_id"], name: "index_relations_on_ancestor_id"
     t.index ["descendant_id"], name: "index_relations_on_descendant_id"
-    t.index ["hierarchy"], name: "index_relations_on_hierarchy"
-    t.index ["invalidate"], name: "index_relations_on_invalidate"
-    t.index ["mention"], name: "index_relations_on_mention"
   end
 
   add_foreign_key "relations", "messages", column: "ancestor_id"

--- a/spec/typed_dag/edge_spec.rb
+++ b/spec/typed_dag/edge_spec.rb
@@ -347,15 +347,15 @@ RSpec.describe 'Edge' do
           it 'expects the transitive relations to be updated' do
             attribute_array = to_attribute_array Relation.non_reflexive
             expect(attribute_array)
-              .to match_array([['A', 'B', 0, 1],
-                               ['A', 'C', 1, 1],
-                               ['A', 'D', 1, 2],
-                               ['A', 'E', 2, 1],
-                               ['B', 'C', 1, 0],
-                               ['B', 'D', 1, 1],
-                               ['B', 'E', 2, 0],
-                               ['C', 'D', 0, 1],
-                               ['C', 'E', 1, 0]])
+              .to match_array([['A', 'B', 0, 1, 1],
+                               ['A', 'C', 1, 1, 1],
+                               ['A', 'D', 1, 2, 1],
+                               ['A', 'E', 2, 1, 1],
+                               ['B', 'C', 1, 0, 1],
+                               ['B', 'D', 1, 1, 1],
+                               ['B', 'E', 2, 0, 1],
+                               ['C', 'D', 0, 1, 1],
+                               ['C', 'E', 1, 0, 1]])
           end
         end
       end
@@ -415,15 +415,15 @@ RSpec.describe 'Edge' do
           it 'expects the transitive relations to be updated' do
             attribute_array = to_attribute_array Relation.non_reflexive
             expect(attribute_array)
-              .to match_array([['F', 'B', 0, 1],
-                               ['F', 'C', 0, 2],
-                               ['F', 'D', 0, 3],
-                               ['F', 'E', 1, 2],
-                               ['B', 'C', 0, 1],
-                               ['B', 'D', 0, 2],
-                               ['B', 'E', 1, 1],
-                               ['C', 'D', 0, 1],
-                               ['C', 'E', 1, 0]])
+              .to match_array([['F', 'B', 0, 1, 1],
+                               ['F', 'C', 0, 2, 1],
+                               ['F', 'D', 0, 3, 1],
+                               ['F', 'E', 1, 2, 1],
+                               ['B', 'C', 0, 1, 1],
+                               ['B', 'D', 0, 2, 1],
+                               ['B', 'E', 1, 1, 1],
+                               ['C', 'D', 0, 1, 1],
+                               ['C', 'E', 1, 0, 1]])
           end
         end
       end
@@ -483,15 +483,15 @@ RSpec.describe 'Edge' do
           it 'expects the transitive relations to be updated' do
             attribute_array = to_attribute_array Relation.non_reflexive
             expect(attribute_array)
-              .to match_array([['A', 'B', 0, 1],
-                               ['A', 'C', 0, 2],
-                               ['A', 'F', 0, 3],
-                               ['A', 'E', 1, 2],
-                               ['B', 'C', 0, 1],
-                               ['B', 'F', 0, 2],
-                               ['B', 'E', 1, 1],
-                               ['C', 'F', 0, 1],
-                               ['C', 'E', 1, 0]])
+              .to match_array([['A', 'B', 0, 1, 1],
+                               ['A', 'C', 0, 2, 1],
+                               ['A', 'F', 0, 3, 1],
+                               ['A', 'E', 1, 2, 1],
+                               ['B', 'C', 0, 1, 1],
+                               ['B', 'F', 0, 2, 1],
+                               ['B', 'E', 1, 1, 1],
+                               ['C', 'F', 0, 1, 1],
+                               ['C', 'E', 1, 0, 1]])
           end
         end
       end
@@ -551,12 +551,12 @@ RSpec.describe 'Edge' do
           it 'expects the transitive relations to be updated' do
             attribute_array = to_attribute_array Relation.non_reflexive
             expect(attribute_array)
-              .to match_array([['A', 'B', 0, 1],
-                               ['F', 'C', 0, 1],
-                               ['C', 'D', 0, 1],
-                               ['C', 'E', 1, 0],
-                               ['F', 'D', 0, 2],
-                               ['F', 'E', 1, 1]])
+              .to match_array([['A', 'B', 0, 1, 1],
+                               ['F', 'C', 0, 1, 1],
+                               ['C', 'D', 0, 1, 1],
+                               ['C', 'E', 1, 0, 1],
+                               ['F', 'D', 0, 2, 1],
+                               ['F', 'E', 1, 1, 1]])
           end
         end
       end

--- a/spec/typed_dag/sql/add_closure_spec.rb
+++ b/spec/typed_dag/sql/add_closure_spec.rb
@@ -1,47 +1,113 @@
 require 'spec_helper'
 
 RSpec.describe TypedDag::Sql::AddClosure do
+  include TypedDag::Specs::Helpers
+
   describe '.sql' do
     let(:relation) { Relation.new id: 11, ancestor_id: 4, descendant_id: 6, invalidate: 1 }
 
-    def harmonize_string(string)
-      string.squish.gsub('( ', '(').gsub(' )', ')').gsub(' , ', ', ')
-    end
-
     it 'produces the correct sql' do
-      expected_sql = <<-SQL
-        INSERT INTO
+      expected_sql = if mysql_db?
+        <<-SQL
+          INSERT INTO
 
-          relations
+            relations
 
-          (ancestor_id,
-          descendant_id,
-          hierarchy, invalidate)
-        SELECT
-          r1.ancestor_id,
-          r2.descendant_id,
-          CASE
-            WHEN r1.descendant_id = r2.ancestor_id AND (r1.hierarchy > 0 OR r2.hierarchy > 0)
-            THEN r1.hierarchy + r2.hierarchy
-            WHEN r1.descendant_id != r2.ancestor_id
-            THEN r1.hierarchy + r2.hierarchy + 0
-            ELSE 0
-            END AS hierarchy,
-          CASE
-            WHEN r1.descendant_id = r2.ancestor_id AND (r1.invalidate > 0 OR r2.invalidate > 0)
-            THEN r1.invalidate + r2.invalidate
-            WHEN r1.descendant_id != r2.ancestor_id
-            THEN r1.invalidate + r2.invalidate + 1
-            ELSE 0
-            END AS invalidate
+            (ancestor_id,
+            descendant_id,
+            hierarchy,
+            invalidate,
+            count)
+          SELECT
+            ancestor_id,
+            descendant_id,
+            hierarchy,
+            invalidate,
+            SUM(count) AS count
+          FROM
+            (SELECT
+              r1.ancestor_id,
+              r2.descendant_id,
+              CASE
+                WHEN r1.descendant_id = r2.ancestor_id AND (r1.hierarchy > 0 OR r2.hierarchy > 0)
+                THEN r1.hierarchy + r2.hierarchy
+                WHEN r1.descendant_id != r2.ancestor_id
+                THEN r1.hierarchy + r2.hierarchy + 0
+                ELSE 0
+                END AS hierarchy,
+              CASE
+                WHEN r1.descendant_id = r2.ancestor_id AND (r1.invalidate > 0 OR r2.invalidate > 0)
+                THEN r1.invalidate + r2.invalidate
+                WHEN r1.descendant_id != r2.ancestor_id
+                THEN r1.invalidate + r2.invalidate + 1
+                ELSE 0
+                END AS invalidate,
+              r1.count * r2.count AS count
+            FROM
+              relations r1
+            JOIN
+              relations r2
+            ON
+              (r1.descendant_id = 4 AND r2.ancestor_id = 6 AND NOT (r1.ancestor_id = 4 AND r2.descendant_id = 6))) unique_rows
+          GROUP BY
+            ancestor_id,
+            descendant_id,
+            hierarchy,
+            invalidate
+          ON DUPLICATE KEY
+          UPDATE count = relations.count + VALUES(count)
+        SQL
+      else
+        <<-SQL
+          INSERT INTO
 
-        FROM
-          relations r1
-        JOIN
-          relations r2
-        ON
-          (r1.descendant_id = 4 AND r2.ancestor_id = 6 AND NOT (r1.ancestor_id = 4 AND r2.descendant_id = 6))
-      SQL
+            relations
+
+            (ancestor_id,
+            descendant_id,
+            hierarchy,
+            invalidate,
+            count)
+          SELECT
+            ancestor_id,
+            descendant_id,
+            hierarchy,
+            invalidate,
+            SUM(count) AS count
+          FROM
+            (SELECT
+              r1.ancestor_id,
+              r2.descendant_id,
+              CASE
+                WHEN r1.descendant_id = r2.ancestor_id AND (r1.hierarchy > 0 OR r2.hierarchy > 0)
+                THEN r1.hierarchy + r2.hierarchy
+                WHEN r1.descendant_id != r2.ancestor_id
+                THEN r1.hierarchy + r2.hierarchy + 0
+                ELSE 0
+                END AS hierarchy,
+              CASE
+                WHEN r1.descendant_id = r2.ancestor_id AND (r1.invalidate > 0 OR r2.invalidate > 0)
+                THEN r1.invalidate + r2.invalidate
+                WHEN r1.descendant_id != r2.ancestor_id
+                THEN r1.invalidate + r2.invalidate + 1
+                ELSE 0
+                END AS invalidate,
+              r1.count * r2.count AS count
+            FROM
+              relations r1
+            JOIN
+              relations r2
+            ON
+              (r1.descendant_id = 4 AND r2.ancestor_id = 6 AND NOT (r1.ancestor_id = 4 AND r2.descendant_id = 6))) unique_rows
+          GROUP BY
+            ancestor_id,
+            descendant_id,
+            hierarchy,
+            invalidate
+          ON CONFLICT (ancestor_id, descendant_id, hierarchy, invalidate)
+          DO UPDATE SET count = relations.count + EXCLUDED.count
+        SQL
+      end
 
       expect(harmonize_string(described_class.sql(relation)))
         .to eql harmonize_string(expected_sql)

--- a/spec/typed_dag/sql/truncate_closure_spec.rb
+++ b/spec/typed_dag/sql/truncate_closure_spec.rb
@@ -1,135 +1,107 @@
 require 'spec_helper'
 
 RSpec.describe TypedDag::Sql::TruncateClosure do
+  include TypedDag::Specs::Helpers
+
   describe '.sql' do
     let(:relation) { Relation.new ancestor_id: 4, descendant_id: 6, invalidate: 1 }
 
-    def harmonize_string(string)
-      string.squish.gsub('( ', '(').gsub(' )', ')')
-    end
-
-    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
-      it 'produces the correct sql for mysql' do
-        expected_sql = <<-SQL
-          DELETE
-            deletion_table
-          FROM
-            relations deletion_table
-          INNER JOIN
-            (SELECT id
-            FROM (
-              SELECT COUNT(*) count, ancestor_id, descendant_id, hierarchy, invalidate
-              FROM (
-                SELECT
-                  r1.ancestor_id,
-                  r2.descendant_id,
-                  CASE
-                    WHEN r1.descendant_id = r2.ancestor_id AND (r1.hierarchy > 0 OR r2.hierarchy > 0)
-                    THEN r1.hierarchy + r2.hierarchy
-                    WHEN r1.descendant_id != r2.ancestor_id
-                    THEN r1.hierarchy + r2.hierarchy + 0
-                    ELSE 0
-                    END AS hierarchy ,
-                  CASE
-                    WHEN r1.descendant_id = r2.ancestor_id AND (r1.invalidate > 0 OR r2.invalidate > 0)
-                    THEN r1.invalidate + r2.invalidate
-                    WHEN r1.descendant_id != r2.ancestor_id
-                    THEN r1.invalidate + r2.invalidate + 1
-                    ELSE 0
-                    END AS invalidate
-
-                FROM
-                  relations r1
-                JOIN
-                  relations r2
-                ON
-                  (r1.descendant_id = 4 AND r2.ancestor_id = 6 AND NOT (r1.ancestor_id = 4 AND r2.descendant_id = 6))
-                ) aggregation
-                GROUP BY ancestor_id, descendant_id, hierarchy, invalidate) criteria
+    it 'produces the correct sql' do
+      expected_sql = if mysql_db?
+        <<-SQL
+          UPDATE
+            relations
+          JOIN
+            (SELECT
+              ancestor_id,
+              descendant_id,
+              hierarchy,
+              invalidate,
+              SUM(count) AS count
+            FROM
+              (SELECT
+                r1.ancestor_id,
+                r2.descendant_id,
+                CASE
+                  WHEN r1.descendant_id = r2.ancestor_id AND (r1.hierarchy > 0 OR r2.hierarchy > 0)
+                  THEN r1.hierarchy + r2.hierarchy
+                  WHEN r1.descendant_id != r2.ancestor_id
+                  THEN r1.hierarchy + r2.hierarchy + 0
+                  ELSE 0
+                  END AS hierarchy,
+                CASE
+                  WHEN r1.descendant_id = r2.ancestor_id AND (r1.invalidate > 0 OR r2.invalidate > 0)
+                  THEN r1.invalidate + r2.invalidate
+                  WHEN r1.descendant_id != r2.ancestor_id
+                  THEN r1.invalidate + r2.invalidate + 1
+                  ELSE 0
+                  END AS invalidate,
+                r1.count * r2.count AS count
+              FROM
+                relations r1
               JOIN
-                (SELECT
-                  id,
-                  ancestor_id,
-                  descendant_id,
-                  hierarchy,
-                  invalidate,
-                  greatest(@cur_count := IF(@cur_ancestor_id = ancestor_id AND @cur_descendant_id = descendant_id AND @cur_hierarchy = hierarchy AND @cur_invalidate = invalidate,
-                                         @cur_count + 1, 1),
-                           least(0, @cur_ancestor_id := ancestor_id, @cur_descendant_id := descendant_id, @cur_hierarchy := hierarchy, @cur_invalidate := invalidate)) AS row_number
-                FROM relations
-                CROSS JOIN (SELECT @cur_count := NULL, @cur_ancestor_id := NULL, @cur_descendant_id := NULL, @cur_hierarchy := NULL, @cur_invalidate := NULL) params_initialization
-                WHERE
-                  ancestor_id IN (SELECT ancestor_id FROM relations WHERE descendant_id = 4) OR ancestor_id = 4
-                AND
-                    descendant_id IN (SELECT descendant_id FROM relations WHERE ancestor_id = 4)
-                ORDER BY ancestor_id, descendant_id, hierarchy, invalidate) ranked
-              ON ranked.ancestor_id = criteria.ancestor_id
-              AND ranked.descendant_id = criteria.descendant_id
-              AND ranked.hierarchy = criteria.hierarchy
-              AND ranked.invalidate = criteria.invalidate
-              AND count >= row_number) selection_table
-            ON
-              deletion_table.id = selection_table.id
+                relations r2
+              ON
+                (r1.descendant_id = 4 AND r2.ancestor_id = 6 AND NOT (r1.ancestor_id = 4 AND r2.descendant_id = 6))) unique_rows
+            GROUP BY
+              ancestor_id,
+              descendant_id,
+              hierarchy,
+              invalidate) removed_relations
+          ON relations.ancestor_id = removed_relations.ancestor_id
+            AND relations.descendant_id = removed_relations.descendant_id
+            AND relations.hierarchy = removed_relations.hierarchy
+            AND relations.invalidate = removed_relations.invalidate
+          SET
+            relations.count = relations.count - removed_relations.count
         SQL
-
-        expect(harmonize_string(described_class.sql(relation)))
-          .to eql harmonize_string(expected_sql)
-      end
-    else
-      it 'produces the correct sql for postgresql' do
+      else
         expected_sql = <<-SQL
-
-          DELETE
+          UPDATE
+            relations
+          SET
+            count = relations.count - removed_relations.count
           FROM
-            relations deletion_table
-          USING
-            (SELECT id
-            FROM (
-              SELECT COUNT(*) count, ancestor_id, descendant_id, hierarchy, invalidate
-              FROM (
-                SELECT
-                  r1.ancestor_id,
-                  r2.descendant_id,
-                  CASE
-                    WHEN r1.descendant_id = r2.ancestor_id AND (r1.hierarchy > 0 OR r2.hierarchy > 0)
-                    THEN r1.hierarchy + r2.hierarchy
-                    WHEN r1.descendant_id != r2.ancestor_id
-                    THEN r1.hierarchy + r2.hierarchy + 0
-                    ELSE 0
-                    END AS hierarchy ,
-                  CASE
-                    WHEN r1.descendant_id = r2.ancestor_id AND (r1.invalidate > 0 OR r2.invalidate > 0)
-                    THEN r1.invalidate + r2.invalidate
-                    WHEN r1.descendant_id != r2.ancestor_id
-                    THEN r1.invalidate + r2.invalidate + 1
-                    ELSE 0
-                    END AS invalidate
-
-                FROM
-                  relations r1
-                JOIN
-                  relations r2
-                ON
-                  (r1.descendant_id = 4 AND r2.ancestor_id = 6 AND NOT (r1.ancestor_id = 4 AND r2.descendant_id = 6))
-                ) aggregation
-                GROUP BY ancestor_id, descendant_id, hierarchy, invalidate) criteria
+            (SELECT
+              ancestor_id,
+              descendant_id,
+              hierarchy,
+              invalidate,
+              SUM(count) AS count
+            FROM
+              (SELECT
+                r1.ancestor_id,
+                r2.descendant_id,
+                CASE
+                  WHEN r1.descendant_id = r2.ancestor_id AND (r1.hierarchy > 0 OR r2.hierarchy > 0)
+                  THEN r1.hierarchy + r2.hierarchy
+                  WHEN r1.descendant_id != r2.ancestor_id
+                  THEN r1.hierarchy + r2.hierarchy + 0
+                  ELSE 0
+                  END AS hierarchy,
+                CASE
+                  WHEN r1.descendant_id = r2.ancestor_id AND (r1.invalidate > 0 OR r2.invalidate > 0)
+                  THEN r1.invalidate + r2.invalidate
+                  WHEN r1.descendant_id != r2.ancestor_id
+                  THEN r1.invalidate + r2.invalidate + 1
+                  ELSE 0
+                  END AS invalidate,
+                r1.count * r2.count AS count
+              FROM
+                relations r1
               JOIN
-                (SELECT *, ROW_NUMBER() OVER(
-                  PARTITION BY ancestor_id, descendant_id, hierarchy, invalidate
-                  )
-                FROM
-                  relations
-                WHERE
-                  ancestor_id IN (SELECT ancestor_id FROM relations WHERE descendant_id = 4) OR ancestor_id = 4
-                AND
-                  descendant_id IN (SELECT descendant_id FROM relations WHERE ancestor_id = 4)) ranked
-              ON ranked.ancestor_id = criteria.ancestor_id
-              AND ranked.descendant_id = criteria.descendant_id
-              AND ranked.hierarchy = criteria.hierarchy
-              AND ranked.invalidate = criteria.invalidate
-              AND count >= row_number) selection_table
-            WHERE
-              deletion_table.id = selection_table.id
+                relations r2
+              ON
+                (r1.descendant_id = 4 AND r2.ancestor_id = 6 AND NOT (r1.ancestor_id = 4 AND r2.descendant_id = 6))) unique_rows
+            GROUP BY
+              ancestor_id,
+              descendant_id,
+              hierarchy,
+              invalidate) removed_relations
+          WHERE relations.ancestor_id = removed_relations.ancestor_id
+            AND relations.descendant_id = removed_relations.descendant_id
+            AND relations.hierarchy = removed_relations.hierarchy
+            AND relations.invalidate = removed_relations.invalidate
         SQL
 
         expect(harmonize_string(described_class.sql(relation)))


### PR DESCRIPTION
Squashes transitive edges starting and ending at the same set of nodes and having the same amount of hops (with the hops having the same type) into a single edge with a counter.

That way, the amount of edges is drastically reduced in cases where deeply nested dags with a large amount of alternative paths are represented.