### PR TITLE
Added UUID support

### DIFF
--- a/lib/typed_dag/sql/relation_access.rb
+++ b/lib/typed_dag/sql/relation_access.rb
@@ -17,15 +17,23 @@ module TypedDag::Sql::RelationAccess
              to: :helper
 
     def id_value
-      relation.id
+      wrapped_value('id')
     end
 
     def from_id_value
-      relation.send(from_column)
+      wrapped_value('from_column')
     end
 
     def to_id_value
-      relation.send(to_column)
+      wrapped_value('to_column')
+    end
+
+    def wrapped_value(column)
+      uuid?(column) ? "'#{relation.send(column)}'" : relation.send(column)
+    end
+
+    def uuid?(column)
+      relation.class.columns_hash[column].type == :uuid
     end
 
     def type_values

--- a/lib/typed_dag/sql/relation_access.rb
+++ b/lib/typed_dag/sql/relation_access.rb
@@ -21,11 +21,11 @@ module TypedDag::Sql::RelationAccess
     end
 
     def from_id_value
-      wrapped_value('from_id')
+      wrapped_value(from_column)
     end
 
     def to_id_value
-      wrapped_value('to_id')
+      wrapped_value(to_column)
     end
 
     def wrapped_value(column)

--- a/lib/typed_dag/sql/relation_access.rb
+++ b/lib/typed_dag/sql/relation_access.rb
@@ -21,11 +21,11 @@ module TypedDag::Sql::RelationAccess
     end
 
     def from_id_value
-      wrapped_value('from_column')
+      wrapped_value('from_id')
     end
 
     def to_id_value
-      wrapped_value('to_column')
+      wrapped_value('to_id')
     end
 
     def wrapped_value(column)


### PR DESCRIPTION
Changed the `TypedDag::Sql::RelationAccess` to add support for nodes using UUIDs. The fix is to simply wrap the IDs in the generated SQL query with single quotes if the field is of type `:uuid`.
I tested in an application that I am developing that uses UUIDs.